### PR TITLE
This commit solves the problem with self signed certificate.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.crewski.hanotify">
 
     <application
+	    android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
This commit solves the problem with self signed certificate. (https://github.com/Crewski/HANotify/issues/3)
Remember that the self signed server certificate must be installed
on android device:
Settings > Security & location > Encryption & credentials > Trusted credentials > User

Now I can register device (msg: Push notification subscriber registered) and send notify from HA

hint from:
https://github.com/facebook/react-native/issues/20488#issuecomment-409535369